### PR TITLE
fix(user): execute code in `willTransition` after promise succeeds

### DIFF
--- a/app/users/login/route.js
+++ b/app/users/login/route.js
@@ -29,16 +29,19 @@ export default Route.extend(UnauthenticatedRouteMixin, {
      * Rollsback and removes the route's user model if it `isNew`.
      *
      * @function actions:willTransition
+     * @param {Object} transition A transition promise
      * @returns {undefined}
      */
-    willTransition() {
+    willTransition(transition) {
       const model = this.modelFor('users/login');
       // `rollbackAttributes` on a model that `isNew` both reverts all
       // attributes to their defaults and causes the record to be removed
       // from the store.
       // Thus, this is a good way to clean up new unsaved records that we
       // want to get rid of.
-      model.rollbackAttributes();
+      transition.then(() => {
+        model.rollbackAttributes();
+      });
     }
   }
 });

--- a/app/users/new/route.js
+++ b/app/users/new/route.js
@@ -30,16 +30,19 @@ export default Route.extend(UnauthenticatedRouteMixin, {
      * Rollsback and removes the route's user model if it `isNew`.
      *
      * @function actions:willTransition
+     * @param {Object} transition A transition promise
      * @returns {undefined}
      */
-    willTransition() {
+    willTransition(transition) {
       const model = this.modelFor('users/new');
       // `rollbackAttributes` on a model that `isNew` both reverts all
       // attributes to their defaults and causes the record to be removed
       // from the store.
       // Thus, this is a good way to clean up new unsaved records that we
       // want to get rid of.
-      if (model.get('isNew')) model.rollbackAttributes();
+      transition.then(() => {
+        if (model.get('isNew')) model.rollbackAttributes();
+      });
     }
   }
 });

--- a/tests/unit/users/login/route-test.js
+++ b/tests/unit/users/login/route-test.js
@@ -37,5 +37,8 @@ test('it should call rollbackAttributes on the model on transition', function (a
       };
     }
   });
-  route.actions.willTransition.call(route);
+  const fakeTransition = {
+    then(callback) { callback(); }
+  };
+  route.actions.willTransition.call(route, fakeTransition);
 });

--- a/tests/unit/users/new/route-test.js
+++ b/tests/unit/users/new/route-test.js
@@ -38,7 +38,10 @@ test('it should call rollbackAttributes on a new model on transition', function 
       };
     }
   });
-  route.actions.willTransition.call(route);
+  const fakeTransition = {
+    then(callback) { callback(); }
+  };
+  route.actions.willTransition.call(route, fakeTransition);
 });
 
 test('it should not call rollbackAttributes on a non-new model on transition', function (assert) {
@@ -57,5 +60,8 @@ test('it should not call rollbackAttributes on a non-new model on transition', f
       };
     }
   });
-  route.actions.willTransition.call(route);
+  const fakeTransition = {
+    then(callback) { callback(); }
+  };
+  route.actions.willTransition.call(route, fakeTransition);
 });


### PR DESCRIPTION
defers user data manipulation until after the route transition is complete and the user data is no
longer displayed

fixes #16